### PR TITLE
Removed Windows build step

### DIFF
--- a/.github/workflows/pipeline-build.yml
+++ b/.github/workflows/pipeline-build.yml
@@ -7,7 +7,6 @@ on:
       branches-ignore:
         - 'gh-pages'
 
-
 jobs:
     build:
         strategy:
@@ -26,12 +25,12 @@ jobs:
           if: matrix.os == 'macos-latest'
           uses: docker-practice/actions-setup-docker@master
 
-        #Run on Linux & macOS
+        #Build without test only on Windows
         - name: Gradle build
-          if: matrix.os != 'windows-latest'
-          run: ./gradlew build
-
-        #Run only on Windows
-        - name: Gradle build (without Test)
-          if: matrix.os == 'windows-latest'
-          run: ./gradlew build -x test
+          run: |
+              if [ "$RUNNER_OS" == "Windows" ]; then
+                  ./gradlew build -x test
+              else
+                  ./gradlew build
+              fi
+          shell: bash


### PR DESCRIPTION
Separated Windows build without test step has
been removed. Runner os is checked directly
in command. In this way skipped tests are not visible.

Signed-off-by: Alberto Battiston <alberto.battiston1311@gmail.com>