### PR TITLE
Refactor actors

### DIFF
--- a/src/main/kotlin/org/eclipse/hara/ddiclient/api/actors/ConnectionManager.kt
+++ b/src/main/kotlin/org/eclipse/hara/ddiclient/api/actors/ConnectionManager.kt
@@ -182,7 +182,8 @@ private constructor(scope: ActorScope) : AbstractActor(scope) {
             this.send(Out.NoAction, state)
         }
 
-        val newState = s.copy(controllerBaseEtag = newControllerBaseEtag, deploymentEtag = etag)
+        val newState = s.copy(controllerBaseEtag = newControllerBaseEtag, deploymentEtag = etag,
+            requireUpdateNotification = false)
                 .withServerSleep(res.config.polling.sleep)
                 .withoutBackoff()
         become(runningReceive(startPing(newState)))

--- a/src/main/kotlin/org/eclipse/hara/ddiclient/api/actors/DeploymentManager.kt
+++ b/src/main/kotlin/org/eclipse/hara/ddiclient/api/actors/DeploymentManager.kt
@@ -19,111 +19,25 @@ import org.eclipse.hara.ddiclient.api.actors.ActionManager.Companion.Message.Upd
 import org.eclipse.hara.ddiclient.api.actors.ConnectionManager.Companion.Message.Out.DeploymentCancelInfo
 import org.eclipse.hara.ddiclient.api.actors.ConnectionManager.Companion.Message.Out.DeploymentInfo
 import org.eclipse.hara.ddiclient.api.MessageListener
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.ObsoleteCoroutinesApi
-import kotlinx.coroutines.launch
-import org.eclipse.hara.ddiclient.api.DeploymentPermitProvider
 
 @OptIn(ObsoleteCoroutinesApi::class, kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 class DeploymentManager
 private constructor(scope: ActorScope) : AbstractActor(scope) {
 
-    private val registry = coroutineContext[HaraClientContext]!!.registry
-    private val softRequest: DeploymentPermitProvider = coroutineContext[HaraClientContext]!!.softDeploymentPermitProvider
-    private val forceRequest: DeploymentPermitProvider = coroutineContext[HaraClientContext]!!.forceDeploymentPermitProvider
     private val connectionManager = coroutineContext[CMActor]!!.ref
     private val notificationManager = coroutineContext[NMActor]!!.ref
     private var waitingAuthJob: Job? = null
     private fun beginningReceive(state: State): Receive = { msg ->
-        when {
-
-            msg is DeploymentInfo && msg.downloadIs(ProvisioningType.forced)  -> {
-                forceDownloadTheArtifact(state, msg, forceRequest)
-            }
-
-            msg is DeploymentInfo && msg.downloadIs(ProvisioningType.attempt) -> {
-                attemptDownloadingTheArtifact(state, msg, softRequest)
-            }
-
-            msg is DeploymentInfo && msg.downloadIs(ProvisioningType.skip) -> {
-                // todo implement download skip option
-                LOG.warn("skip download not yet implemented (used attempt)")
-                attemptDownloadingTheArtifact(state, msg, softRequest)
-            }
-
-            msg is DeploymentCancelInfo -> {
-                stopUpdateAndNotify(msg)
-            }
-
-            else -> unhandled(msg)
-        }
-    }
-
-    private suspend fun forceDownloadTheArtifact(state: State,
-                                                 msg: DeploymentInfo,
-                                                 deploymentPermitProvider: DeploymentPermitProvider) {
-        val message = "Start downloading artifacts"
-        LOG.info(message)
-        sendFeedback(message)
-        val result = deploymentPermitProvider.downloadAllowed().await()
-        if (result) {
-            become(downloadingReceive(state.copy(deplBaseResp = msg.info)))
-            child("downloadManager")!!.send(msg)
-        } else {
-            LOG.info("Authorization denied for download files")
-        }
-    }
-
-    private suspend fun attemptDownloadingTheArtifact(state: State,
-                                                      msg: DeploymentInfo,
-                                                      deploymentPermitProvider: DeploymentPermitProvider) {
-        val message = "Waiting authorization to download"
-        LOG.info(message)
-        sendFeedback(message)
-        become(waitingDownloadAuthorization(state.copy(deplBaseResp = msg.info)))
-        notificationManager.send(MessageListener.Message.State
-            .WaitingDownloadAuthorization(false))
-        waitingAuthJob?.cancel()
-        waitingAuthJob = launch {
-            val result = deploymentPermitProvider.downloadAllowed().await()
-            if (result) {
-                channel.send(Message.DownloadGranted)
-            } else {
-                LOG.info("Authorization denied for download files")
-            }
-            waitingAuthJob = null
-        }
-    }
-
-    private fun waitingDownloadAuthorization(state: State): Receive = { msg ->
-        when (msg) {
+        when(msg) {
             is DeploymentInfo -> {
-                when {
-
-                    msg.downloadIs(ProvisioningType.attempt) && !msg.forceAuthRequest -> {}
-
-                    else -> {
-                        become(beginningReceive(state))
-                        channel.send(msg)
-                    }
-                }
-            }
-
-            is Message.DownloadGranted -> {
-                val message = "Authorization granted for downloading files"
-                LOG.info(message)
-                sendFeedback(message)
-                become(downloadingReceive(state))
-                child("downloadManager")!!.send(DeploymentInfo(state.deplBaseResp!!))
+                become(downloadingReceive(state.copy(deplBaseResp = msg.info)))
+                child("downloadManager")!!.send(msg)
             }
 
             is DeploymentCancelInfo -> {
                 stopUpdateAndNotify(msg)
-            }
-
-            is CancelForced -> {
-                stopUpdate()
             }
 
             else -> unhandled(msg)
@@ -133,29 +47,9 @@ private constructor(scope: ActorScope) : AbstractActor(scope) {
     private fun downloadingReceive(state: State): Receive = { msg ->
         when (msg) {
             is Message.DownloadFinished -> {
-                val message: String
-                if (state.updateIs(ProvisioningType.forced)) {
-                    message = "Start updating the device"
-                    waitingAuthJob = launch(Dispatchers.IO) {
-                        if(forceRequest.updateAllowed().await()){
-                            become(updatingReceive())
-                            child("updateManager")!!.send(DeploymentInfo(state.deplBaseResp!!))
-                        } else {
-                            LOG.info("Authorization denied for update")
-                        }
-                        waitingAuthJob = null
-                    }
-                } else {
-                    message = "Waiting authorization to update"
-                    become(waitingUpdateAuthorization(state))
-                    notificationManager.send(MessageListener.Message.State.WaitingUpdateAuthorization(state.updateIs(ProvisioningType.forced)))
-                    waitingAuthJob = launch(Dispatchers.IO) {
-                        onAuthorizationReceive(softRequest)
-                        waitingAuthJob = null
-                    }
-                }
-                LOG.info(message)
-                sendFeedback(message)
+                become(updatingReceive())
+                child("updateManager")!!.send(DeploymentInfo(state.deplBaseResp!!))
+
             }
             is Message.DownloadFailed -> {
                 LOG.error("download failed")
@@ -167,42 +61,6 @@ private constructor(scope: ActorScope) : AbstractActor(scope) {
             is CancelForced -> {
                 stopUpdate()
             }
-            else -> unhandled(msg)
-        }
-    }
-
-    private suspend fun onAuthorizationReceive(deploymentPermitProvider: DeploymentPermitProvider){
-        if(deploymentPermitProvider.updateAllowed().await()){
-            channel.send(Message.UpdateGranted)
-        } else {
-            LOG.info("Authorization denied for update")
-        }
-    }
-
-    private fun waitingUpdateAuthorization(state: State): Receive = { msg ->
-        when (msg) {
-
-            is DeploymentInfo -> {
-                become(downloadingReceive(state.copy(deplBaseResp = msg.info)))
-                channel.send(Message.DownloadFinished)
-            }
-
-            is Message.UpdateGranted -> {
-                val message = "Authorization granted for update"
-                LOG.info(message)
-                sendFeedback(message)
-                become(updatingReceive())
-                child("updateManager")!!.send(DeploymentInfo(state.deplBaseResp!!))
-            }
-
-            is DeploymentCancelInfo -> {
-                stopUpdateAndNotify(msg)
-            }
-
-            is CancelForced -> {
-                stopUpdate()
-            }
-
             else -> unhandled(msg)
         }
     }
@@ -284,8 +142,6 @@ private constructor(scope: ActorScope) : AbstractActor(scope) {
         }
 
         sealed class Message {
-            object DownloadGranted : Message()
-            object UpdateGranted : Message()
             object DownloadFinished : Message()
             data class DownloadFailed(val details: List<String>) : Message()
             object UpdateFailed : Message()

--- a/src/main/kotlin/org/eclipse/hara/ddiclient/api/actors/UpdateManager.kt
+++ b/src/main/kotlin/org/eclipse/hara/ddiclient/api/actors/UpdateManager.kt
@@ -10,70 +10,151 @@
 
 package org.eclipse.hara.ddiclient.api.actors
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import org.eclipse.hara.ddi.api.model.DeploymentFeedbackRequest
 import org.eclipse.hara.ddiclient.api.UpdaterRegistry
 import org.eclipse.hara.ddiclient.api.actors.ConnectionManager.Companion.Message.In.DeploymentFeedback
 import org.eclipse.hara.ddiclient.api.actors.ConnectionManager.Companion.Message.Out.DeploymentInfo
 import org.eclipse.hara.ddiclient.api.MessageListener
 import org.eclipse.hara.ddiclient.api.Updater
+import org.eclipse.hara.ddi.api.model.DeploymentFeedbackRequest.Status.Result.Progress
+import org.eclipse.hara.ddi.api.model.DeploymentFeedbackRequest.Status.Execution
+import org.eclipse.hara.ddi.api.model.DeploymentFeedbackRequest.Status.Execution.proceeding
+import org.eclipse.hara.ddi.api.model.DeploymentFeedbackRequest.Status.Execution.closed
+import org.eclipse.hara.ddi.api.model.DeploymentFeedbackRequest.Status.Result.Finished
+import org.eclipse.hara.ddi.api.model.DeploymentFeedbackRequest.Status.Result.Finished.none
+import org.eclipse.hara.ddi.api.model.DeploymentFeedbackRequest.Status.Result.Finished.success
+import org.eclipse.hara.ddi.api.model.DeploymentFeedbackRequest.Status.Result.Finished.failure
 import kotlinx.coroutines.ObsoleteCoroutinesApi
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import org.eclipse.hara.ddi.api.model.CancelFeedbackRequest
+import org.eclipse.hara.ddi.api.model.DeploymentBaseResponse
+import org.eclipse.hara.ddiclient.api.DeploymentPermitProvider
 
 @OptIn(ObsoleteCoroutinesApi::class)
 class UpdateManager
 private constructor(scope: ActorScope) : AbstractActor(scope) {
 
     private val registry = coroutineContext[HaraClientContext]!!.registry
+    private val softRequest: DeploymentPermitProvider = coroutineContext[HaraClientContext]!!.softDeploymentPermitProvider
+    private val forceRequest: DeploymentPermitProvider = coroutineContext[HaraClientContext]!!.forceDeploymentPermitProvider
     private val pathResolver = coroutineContext[HaraClientContext]!!.pathResolver
     private val connectionManager = coroutineContext[CMActor]!!.ref
     private val notificationManager = coroutineContext[NMActor]!!.ref
+    private var waitingAuthJob: Job? = null
 
     private fun beforeStartReceive(): Receive = { msg ->
         when (msg) {
 
             is DeploymentInfo -> {
-                LOG.info("START UPDATING!!!")
-                notificationManager.send(MessageListener.Message.State.Updating)
-                val updaters = registry.allUpdatersWithSwModulesOrderedForPriority(msg.info.deployment.chunks)
-                val details = mutableListOf("Details:")
-                val updaterError = update(updaters, msg, details)
-
-                when{
-                    updaters.all { it.softwareModules.isEmpty() } -> {
-                        parent!!.send(DeploymentManager.Companion.Message.UpdateFinished)
-                        sendFeedback(msg.info.id,
-                            DeploymentFeedbackRequest.Status.Execution.closed,
-                            DeploymentFeedbackRequest.Status.Result.Progress(0,0),
-                            DeploymentFeedbackRequest.Status.Result.Finished.success,
-                            "No update applied"
-                        )
-                        notificationManager.send(MessageListener.Message.Event.NoUpdate)
+                val state = DeploymentManager.Companion.State(deplBaseResp = msg.info)
+                val message = when {
+                    state.updateIs(DeploymentBaseResponse.Deployment.ProvisioningType.forced) -> {
+                        forceUpdateDevice(state)
                     }
-
-                    updaterError.isNotEmpty() -> {
-                        LOG.warn("update ${updaterError[0].first} failed!")
-                        parent!!.send(DeploymentManager.Companion.Message.UpdateFailed)
-                        sendFeedback(msg.info.id,
-                            DeploymentFeedbackRequest.Status.Execution.closed,
-                            DeploymentFeedbackRequest.Status.Result.Progress(updaters.size, updaterError[0].first),
-                            DeploymentFeedbackRequest.Status.Result.Finished.failure,
-                            *details.toTypedArray())
-                        notificationManager.send(MessageListener.Message.Event.UpdateFinished(successApply = false, details = details))
-                    }
-
                     else -> {
-                        parent!!.send(DeploymentManager.Companion.Message.UpdateFinished)
-                        sendFeedback(msg.info.id,
-                            DeploymentFeedbackRequest.Status.Execution.closed,
-                            DeploymentFeedbackRequest.Status.Result.Progress(updaters.size, updaters.size),
-                            DeploymentFeedbackRequest.Status.Result.Finished.success,
-                            *details.toTypedArray())
-                        notificationManager.send(MessageListener.Message.Event.UpdateFinished(successApply = true, details = details))
+                        attemptUpdateDevice(state)
                     }
                 }
+                LOG.info(message)
+                sendFeedback(message, proceeding, Progress(0, 0), none)
             }
 
             else -> unhandled(msg)
+        }
+    }
+
+    private fun waitingUpdateAuthorization(state: DeploymentManager.Companion.State): Receive = { msg ->
+        when (msg) {
+
+            is DeploymentInfo -> {
+                become(beforeStartReceive())
+                channel.send(msg)
+            }
+
+            is Message.UpdateGranted -> {
+                val message = "Authorization granted for update"
+                LOG.info(message)
+                sendFeedback(message, proceeding, Progress(0, 0), none)
+                startUpdateProcedure(DeploymentInfo(state.deplBaseResp!!))
+            }
+
+            is ConnectionManager.Companion.Message.Out.DeploymentCancelInfo -> {
+                stopUpdateAndNotify(msg)
+            }
+
+            is ActionManager.Companion.Message.CancelForced -> {
+                stopUpdate()
+            }
+
+            else -> unhandled(msg)
+        }
+    }
+
+    private fun forceUpdateDevice(state: DeploymentManager.Companion.State): String {
+        waitingAuthJob = launch(Dispatchers.IO) {
+            forceRequest.onAuthorizationReceive {
+                startUpdateProcedure(DeploymentInfo(state.deplBaseResp!!))
+            }
+            waitingAuthJob = null
+        }
+        return "Start updating the device"
+    }
+
+    private suspend fun attemptUpdateDevice(state: DeploymentManager.Companion.State): String {
+        become(waitingUpdateAuthorization(state))
+        notificationManager.send(MessageListener.Message.State.WaitingUpdateAuthorization(state.updateIs(
+            DeploymentBaseResponse.Deployment.ProvisioningType.forced)))
+        waitingAuthJob = launch(Dispatchers.IO) {
+            softRequest.onAuthorizationReceive {
+                channel.send(Message.UpdateGranted)
+            }
+            waitingAuthJob = null
+        }
+        return "Waiting authorization to update"
+    }
+
+    private suspend fun DeploymentPermitProvider.onAuthorizationReceive(
+        onGrantAuthorization: suspend ()-> Unit){
+        if(updateAllowed().await()){
+            onGrantAuthorization.invoke()
+        } else {
+            LOG.info("Authorization denied for update")
+        }
+    }
+
+    private suspend fun startUpdateProcedure(msg: DeploymentInfo) {
+        LOG.info("START UPDATING!!!")
+        notificationManager.send(MessageListener.Message.State.Updating)
+        val updaters = registry.allUpdatersWithSwModulesOrderedForPriority(msg.info.deployment.chunks)
+        val details = mutableListOf("Details:")
+        val updaterError = update(updaters, msg, details)
+
+        when{
+            updaters.all { it.softwareModules.isEmpty() } -> {
+                parent!!.send(DeploymentManager.Companion.Message.UpdateFinished)
+                sendFeedback(msg.info.id, closed, Progress(0,0), success,
+                    "No update applied"
+                )
+                notificationManager.send(MessageListener.Message.Event.NoUpdate)
+            }
+
+            updaterError.isNotEmpty() -> {
+                LOG.warn("update ${updaterError[0].first} failed!")
+                parent!!.send(DeploymentManager.Companion.Message.UpdateFailed)
+                sendFeedback(msg.info.id, closed, Progress(updaters.size, updaterError[0].first),
+                    failure, *details.toTypedArray())
+                notificationManager.send(MessageListener.Message.Event.UpdateFinished(successApply = false, details = details))
+            }
+
+            else -> {
+                parent!!.send(DeploymentManager.Companion.Message.UpdateFinished)
+                sendFeedback(msg.info.id, closed, Progress(updaters.size, updaters.size),
+                    success, *details.toTypedArray())
+                notificationManager.send(MessageListener.Message.Event.UpdateFinished(successApply = true, details = details))
+            }
         }
     }
 
@@ -91,11 +172,8 @@ private constructor(scope: ActorScope) : AbstractActor(scope) {
                     }.toSet(), object : Updater.Messenger {
                         override fun sendMessageToServer(vararg msg: String) {
                             runBlocking {
-                                sendFeedback(message.info.id,
-                                        DeploymentFeedbackRequest.Status.Execution.proceeding,
-                                        DeploymentFeedbackRequest.Status.Result.Progress(updaters.size, index),
-                                        DeploymentFeedbackRequest.Status.Result.Finished.none,
-                                        *msg)
+                                sendFeedback(message.info.id, proceeding,
+                                    Progress(updaters.size, index), none, *msg)
                             }
                         }
                     })
@@ -109,9 +187,9 @@ private constructor(scope: ActorScope) : AbstractActor(scope) {
 
     private suspend fun sendFeedback(
             id: String,
-            execution: DeploymentFeedbackRequest.Status.Execution,
-            progress: DeploymentFeedbackRequest.Status.Result.Progress,
-            finished: DeploymentFeedbackRequest.Status.Result.Finished,
+            execution: Execution,
+            progress: Progress,
+            finished: Finished,
             vararg messages: String
     ) {
         val request = DeploymentFeedbackRequest.newInstance(id, execution, progress, finished, *messages)
@@ -128,11 +206,30 @@ private constructor(scope: ActorScope) : AbstractActor(scope) {
                     { Updater.SwModuleWithPath.Artifact(it.filename, it.hashes, it.size, pathCalculator(it)) }.toSet()
             )
 
+    private suspend fun stopUpdateAndNotify(msg: ConnectionManager.Companion.Message.Out.DeploymentCancelInfo) {
+        connectionManager.send(ConnectionManager.Companion.Message.In.CancelFeedback(
+            CancelFeedbackRequest.newInstance(msg.info.cancelAction.stopId,
+                CancelFeedbackRequest.Status.Execution.closed,
+                CancelFeedbackRequest.Status.Result.Finished.success)))
+        stopUpdate()
+    }
+
+    private suspend fun stopUpdate() {
+        LOG.info("Stopping update")
+        channel.cancel()
+        notificationManager.send(MessageListener.Message.State.CancellingUpdate)
+        parent!!.send(ActionManager.Companion.Message.UpdateStopped)
+    }
+
     init {
         become(beforeStartReceive())
     }
 
     companion object {
         fun of(scope: ActorScope) = UpdateManager(scope)
+
+        sealed class Message {
+            object UpdateGranted : Message()
+        }
     }
 }


### PR DESCRIPTION
Refactor workflow to handle authorization requests properly 

Refactored DownloadManager and UpdateManager
Move corresponding authorization requests to Download and Update manager to handle them in their own actor
Check if the artifacts are already downloaded before asking for authorization or even starting the download again
