### PR TITLE
Fix deployment feedback request failure

### DIFF
--- a/src/main/kotlin/org/eclipse/hara/ddiclient/api/actors/DownloadManager.kt
+++ b/src/main/kotlin/org/eclipse/hara/ddiclient/api/actors/DownloadManager.kt
@@ -86,7 +86,6 @@ private constructor(scope: ActorScope) : AbstractActor(scope) {
     private suspend fun forceDownloadTheArtifact(msg: DeploymentInfo) {
         val message = "Start downloading artifacts"
         LOG.info(message)
-        feedback(message, proceeding, Progress(0, 0), none)
         forceRequest.onAuthorizationReceive {
             startDownloadProcedure(msg)
         }
@@ -95,7 +94,7 @@ private constructor(scope: ActorScope) : AbstractActor(scope) {
     private suspend fun attemptDownloadingTheArtifact(state: State, msg: DeploymentInfo) {
         val message = "Waiting authorization to download"
         LOG.info(message)
-        feedback(message, proceeding, Progress(0, 0), none)
+        feedback(msg.info.id, proceeding, Progress(0, 0), none, message)
         become(waitingDownloadAuthorization(state.copy(deplBaseResp = msg.info)))
         notificationManager.send(MessageListener.Message.State
             .WaitingDownloadAuthorization(false))
@@ -185,7 +184,7 @@ private constructor(scope: ActorScope) : AbstractActor(scope) {
             is Message.DownloadGranted -> {
                 val message = "Authorization granted for downloading files"
                 LOG.info(message)
-                feedback(message, proceeding, Progress(0, 0), none)
+                feedback(state.deplBaseResp.id, proceeding, Progress(0, 0), none, message)
                 startDownloadProcedure(DeploymentInfo(state.deplBaseResp))
             }
 

--- a/src/main/kotlin/org/eclipse/hara/ddiclient/api/actors/UpdateManager.kt
+++ b/src/main/kotlin/org/eclipse/hara/ddiclient/api/actors/UpdateManager.kt
@@ -55,11 +55,12 @@ private constructor(scope: ActorScope) : AbstractActor(scope) {
                         forceUpdateDevice(state)
                     }
                     else -> {
-                        attemptUpdateDevice(state)
+                        val softMsg = attemptUpdateDevice(state)
+                        sendFeedback(msg.info.id, proceeding, Progress(0, 0), none, softMsg)
+                        softMsg
                     }
                 }
                 LOG.info(message)
-                sendFeedback(message, proceeding, Progress(0, 0), none)
             }
 
             else -> unhandled(msg)
@@ -77,8 +78,8 @@ private constructor(scope: ActorScope) : AbstractActor(scope) {
             is Message.UpdateGranted -> {
                 val message = "Authorization granted for update"
                 LOG.info(message)
-                sendFeedback(message, proceeding, Progress(0, 0), none)
-                startUpdateProcedure(DeploymentInfo(state.deplBaseResp!!))
+                sendFeedback(state.deplBaseResp!!.id, proceeding, Progress(0, 0), none, message)
+                startUpdateProcedure(DeploymentInfo(state.deplBaseResp))
             }
 
             is ConnectionManager.Companion.Message.Out.DeploymentCancelInfo -> {

--- a/src/test/kotlin/org/eclipse/hara/ddiclient/integrationtest/SuccessfulSoftUpdateWithDownloadAndUpdateAlwaysAllowed.kt
+++ b/src/test/kotlin/org/eclipse/hara/ddiclient/integrationtest/SuccessfulSoftUpdateWithDownloadAndUpdateAlwaysAllowed.kt
@@ -13,6 +13,8 @@ package org.eclipse.hara.ddiclient.integrationtest
 import org.eclipse.hara.ddiclient.integrationtest.TestUtils.defaultActionStatusOnStart
 import org.eclipse.hara.ddiclient.integrationtest.TestUtils.endMessagesOnSuccessUpdate
 import org.eclipse.hara.ddiclient.integrationtest.TestUtils.filesDownloadedInOsWithAppsPairedToServerFile
+import org.eclipse.hara.ddiclient.integrationtest.TestUtils.messagesOnSoftDownloadAuthorization
+import org.eclipse.hara.ddiclient.integrationtest.TestUtils.messagesOnSoftUpdateAuthorization
 import org.eclipse.hara.ddiclient.integrationtest.TestUtils.messagesOnSuccessfullyDownloadOsWithAppDistribution
 import org.eclipse.hara.ddiclient.integrationtest.TestUtils.startMessagesOnUpdateFond
 import org.testng.annotations.DataProvider
@@ -36,7 +38,9 @@ class SuccessfulSoftUpdateWithDownloadAndUpdateAlwaysAllowed : AbstractClientTes
         val contentEntriesOnFinish = ActionStatus(
             setOf(
                 *endMessagesOnSuccessUpdate,
+                *messagesOnSoftUpdateAuthorization,
                 *messagesOnSuccessfullyDownloadOsWithAppDistribution(targetId),
+                *messagesOnSoftDownloadAuthorization,
                 *startMessagesOnUpdateFond
             )
         )

--- a/src/test/kotlin/org/eclipse/hara/ddiclient/integrationtest/Utils.kt
+++ b/src/test/kotlin/org/eclipse/hara/ddiclient/integrationtest/Utils.kt
@@ -300,6 +300,28 @@ object TestUtils {
             )
     )
 
+    val messagesOnSoftDownloadAuthorization = arrayOf(
+        ActionStatus.ContentEntry(
+            ActionStatus.ContentEntry.Type.running,
+            listOf("Authorization granted for downloading files")
+        ),
+        ActionStatus.ContentEntry(
+            ActionStatus.ContentEntry.Type.running,
+            listOf("Waiting authorization to download")
+        )
+    )
+
+    val messagesOnSoftUpdateAuthorization = arrayOf(
+        ActionStatus.ContentEntry(
+            ActionStatus.ContentEntry.Type.running,
+            listOf("Authorization granted for update")
+        ),
+        ActionStatus.ContentEntry(
+            ActionStatus.ContentEntry.Type.running,
+            listOf("Waiting authorization to update")
+        )
+    )
+
     val firstActionEntry = ActionStatus.ContentEntry(
             ActionStatus.ContentEntry.Type.running,
             listOf(null)


### PR DESCRIPTION
In some deployment feedback requests, the message was set as actionId or was not send to the server at all
Refactored the tests with the new changes.