### PR TITLE
Update VM used by virtual-device to Java 11

### DIFF
--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -7,7 +7,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-FROM openjdk:8
+FROM eclipse-temurin:11
 
 COPY ./virtual-device /client
 


### PR DESCRIPTION
Since we are building with JDK 11:
https://github.com/eclipse/hara-ddiclient/commit/cd041b6bbdf6925b88e044738af451a880e3dc51

the virtual device docker container no longer runs with JDK 8:
```
$ docker run hara-virtual-device:2.0.0
Error: A JNI error has occurred, please check your installation and try again
Exception in thread "main" java.lang.UnsupportedClassVersionError: org/eclipse/hara/ddiclient/virtualdevice/MainKt has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
        at java.lang.ClassLoader.defineClass1(Native Method)
        at java.lang.ClassLoader.defineClass(ClassLoader.java:756)
        at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
        at java.net.URLClassLoader.defineClass(URLClassLoader.java:473)
        at java.net.URLClassLoader.access$100(URLClassLoader.java:74)
        at java.net.URLClassLoader$1.run(URLClassLoader.java:369)
        at java.net.URLClassLoader$1.run(URLClassLoader.java:363)
        at java.security.AccessController.doPrivileged(Native Method)
        at java.net.URLClassLoader.findClass(URLClassLoader.java:362)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
        at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
        at sun.launcher.LauncherHelper.checkAndLoadMain(LauncherHelper.java:601)
```

Update docker container to eclipse-temurin 11.