### PR TITLE
Fix build warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -140,7 +140,7 @@ project(':virtual-device'){
     mainClassName = 'org.eclipse.hara.ddiclient.virtualdevice.MainKt'
 
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-        kotlinOptions.freeCompilerArgs += ["-Xopt-in=kotlin.RequiresOptIn"]
+        kotlinOptions.freeCompilerArgs += ["-opt-in=kotlin.RequiresOptIn"]
     }
 }
 
@@ -252,10 +252,6 @@ test.finalizedBy stopHawkbitServer
 
 group 'org.eclipse.hara.hara-ddiclient'
 version app_version
-
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-    kotlinOptions.freeCompilerArgs += ["-Xuse-experimental=kotlin.Experimental"]
-}
 
 test {
     useTestNG()


### PR DESCRIPTION
Fix the following build warnings:

~~~
> Task :compileKotlin
w: Flag is not supported by this version of the compiler: -Xuse-experimental=kotlin.Experimental 
~~~

~~~
> Task :virtual-device:compileKotlin
w: Argument -Xopt-in is deprecated. Please use -opt-in instead 
~~~